### PR TITLE
fix: Fixed the region bug

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
           gcloud functions deploy "$func_name" \
             --gen2 \
             --runtime=nodejs20 \
-            --region=us-south1 \
+            --region=us-central1 \
             --source=. \
             --trigger-http \
             --allow-unauthenticated \


### PR DESCRIPTION
For some reason, putting the region as `us-south1` (Dallas) in the build config made the API URL not work for some reason, so for safety reasons we're going to stay on `us-central1`. If anyone wants to look into this you can but if it works it works :eyes: