### PR TITLE
feat: Add Instagram social link to the officer schema

### DIFF
--- a/src/types/officer.ts
+++ b/src/types/officer.ts
@@ -24,6 +24,7 @@ export const DivisionEnum = z.enum([
 export const SocialLinksSchema = z.object({
 	linkedin: z.string().url().optional(),
 	github: z.string().url().optional(),
+	instagram: z.string().url().optional(),
 	personalEmail: z.string().email().optional(),
 });
 


### PR DESCRIPTION
This pull request makes a minor update to the officer social links schema by adding support for an optional Instagram URL. This allows officer profiles to include an Instagram link if available. Closes #28.

- Added an optional `instagram` field to the `SocialLinksSchema` in `src/types/officer.ts`.